### PR TITLE
Fix cached index rebuild after mutations

### DIFF
--- a/src/api/database.ts
+++ b/src/api/database.ts
@@ -592,6 +592,7 @@ export class VectorDB {
   async clear(): Promise<void> {
     await this.ensureInitialized();
     await this.storage.clear();
+    await this.searchEngine.clearIndex();
   }
 
   /**
@@ -709,8 +710,13 @@ export class VectorDB {
       updateTimestamp?: boolean;
     },
   ): Promise<void> {
+    const validatedId = InputValidator.validateVectorId(id);
+    const validatedMetadata = InputValidator.validateMetadata(metadata);
+
     await this.ensureInitialized();
-    await this.storage.updateMetadata(id, metadata, options);
+    await this.storage.updateMetadata(validatedId, validatedMetadata, options);
+
+    await this.searchEngine.rebuildIndex({ loadFromCache: false });
   }
 
   /**
@@ -729,16 +735,21 @@ export class VectorDB {
     errors: Array<{ id: string; error: Error }>;
   }> {
     await this.ensureInitialized();
+    const validatedIds = InputValidator.validateVectorIds(
+      updates.map((update) => update.id),
+    );
 
     // Validate and convert vectors
-    const processedUpdates = updates.map((update) => {
+    const processedUpdates = updates.map((update, index) => {
       const processed: {
         id: string;
         vector?: Float32Array;
         metadata?: Record<string, unknown>;
-      } = { id: update.id };
+      } = { id: validatedIds[index]! };
 
       if (update.vector) {
+        VectorFormatHandler.validate(update.vector, this.dimension);
+
         if (update.vector.length !== this.dimension) {
           throw new DimensionMismatchError(this.dimension, update.vector.length);
         }
@@ -746,12 +757,15 @@ export class VectorDB {
       }
 
       if (update.metadata !== undefined) {
-        processed.metadata = update.metadata;
+        processed.metadata = InputValidator.validateMetadata(update.metadata);
       }
 
       return processed;
     });
 
-    return this.storage.updateBatch(processedUpdates, options);
+    const result = await this.storage.updateBatch(processedUpdates, options);
+    await this.searchEngine.rebuildIndex({ loadFromCache: false });
+
+    return result;
   }
 }

--- a/src/api/database.ts
+++ b/src/api/database.ts
@@ -710,11 +710,8 @@ export class VectorDB {
       updateTimestamp?: boolean;
     },
   ): Promise<void> {
-    const validatedId = InputValidator.validateVectorId(id);
-    const validatedMetadata = InputValidator.validateMetadata(metadata);
-
     await this.ensureInitialized();
-    await this.storage.updateMetadata(validatedId, validatedMetadata, options);
+    await this.storage.updateMetadata(id, metadata, options);
 
     await this.searchEngine.rebuildIndex({ loadFromCache: false });
   }
@@ -735,21 +732,16 @@ export class VectorDB {
     errors: Array<{ id: string; error: Error }>;
   }> {
     await this.ensureInitialized();
-    const validatedIds = InputValidator.validateVectorIds(
-      updates.map((update) => update.id),
-    );
 
     // Validate and convert vectors
-    const processedUpdates = updates.map((update, index) => {
+    const processedUpdates = updates.map((update) => {
       const processed: {
         id: string;
         vector?: Float32Array;
         metadata?: Record<string, unknown>;
-      } = { id: validatedIds[index]! };
+      } = { id: update.id };
 
       if (update.vector) {
-        VectorFormatHandler.validate(update.vector, this.dimension);
-
         if (update.vector.length !== this.dimension) {
           throw new DimensionMismatchError(this.dimension, update.vector.length);
         }
@@ -757,7 +749,7 @@ export class VectorDB {
       }
 
       if (update.metadata !== undefined) {
-        processed.metadata = InputValidator.validateMetadata(update.metadata);
+        processed.metadata = update.metadata;
       }
 
       return processed;

--- a/src/search/index-persistence.ts
+++ b/src/search/index-persistence.ts
@@ -398,6 +398,14 @@ export class IndexCache {
   }
 
   /**
+   * Remove an index from cache and persistence.
+   */
+  async deleteIndex(indexId: string): Promise<void> {
+    this.cache.delete(indexId);
+    await this.persistenceManager.deleteIndex(indexId);
+  }
+
+  /**
    * Evict least recently used index
    */
   private evictLeastRecentlyUsed(): void {

--- a/src/search/search-engine.ts
+++ b/src/search/search-engine.ts
@@ -72,12 +72,12 @@ export class SearchEngine {
     this.useGPU = options?.useGPU ?? false;
     this.gpuThreshold = options?.gpuConfig?.gpuThreshold ?? 5000;
 
+    if (options?.database) {
+      this.indexCache = new IndexCache(options.database as VectorDatabase);
+    }
+
     if (this.useIndex) {
       this.hnswIndex = new HNSWIndex(distanceMetric, options?.indexConfig);
-
-      if (options?.database) {
-        this.indexCache = new IndexCache(options.database as VectorDatabase);
-      }
     }
 
     // Initialize worker pool if workers are enabled
@@ -662,11 +662,9 @@ export class SearchEngine {
    * Clear the active index and any persisted snapshot for this search engine.
    */
   async clearIndex(): Promise<void> {
-    if (!this.useIndex || !this.hnswIndex) {
-      return;
+    if (this.hnswIndex) {
+      this.hnswIndex.clear();
     }
-
-    this.hnswIndex.clear();
 
     if (this.indexCache) {
       await this.indexCache.deleteIndex(this.indexId);

--- a/src/search/search-engine.ts
+++ b/src/search/search-engine.ts
@@ -659,15 +659,30 @@ export class SearchEngine {
   }
 
   /**
+   * Clear the active index and any persisted snapshot for this search engine.
+   */
+  async clearIndex(): Promise<void> {
+    if (!this.useIndex || !this.hnswIndex) {
+      return;
+    }
+
+    this.hnswIndex.clear();
+
+    if (this.indexCache) {
+      await this.indexCache.deleteIndex(this.indexId);
+    }
+  }
+
+  /**
    * Rebuild the index from storage
    */
-  async rebuildIndex(): Promise<void> {
+  async rebuildIndex(options: { loadFromCache?: boolean } = {}): Promise<void> {
     if (!this.useIndex || !this.hnswIndex) {
       return;
     }
 
     // Try to load from cache/persistence first
-    if (this.indexCache) {
+    if (options.loadFromCache !== false && this.indexCache) {
       const cached = await this.indexCache.getIndex(this.indexId);
       if (cached) {
         this.hnswIndex = cached.index;

--- a/tests/integration/vector-database.integration.test.ts
+++ b/tests/integration/vector-database.integration.test.ts
@@ -320,6 +320,84 @@ describe('Vector Database Integration Tests', () => {
     });
   });
 
+  describe('Indexed Mutation Consistency', () => {
+    beforeEach(async () => {
+      await db.delete();
+      db = new VectorDB(`${testDBName}-indexed-mutations`, 2, {
+        autoEviction: false,
+        useIndex: true,
+      });
+      await db.init();
+    });
+
+    it('should clear cached and persisted indexes when clearing vectors', async () => {
+      await db.addVector('first-vector', [1, 0], { label: 'first' });
+      await db.addVector('second-vector', [0, 1], { label: 'second' });
+      await db.rebuildIndex();
+
+      expect(db.getIndexStats().nodeCount).toBe(2);
+
+      await db.clear();
+
+      const stats = await db.getStats();
+      expect(stats.vectorCount).toBe(0);
+      expect(db.getIndexStats().nodeCount).toBe(0);
+      expect(await db.search([1, 0], 5, { includeMetadata: true })).toEqual([]);
+    });
+
+    it('should force-rebuild cached indexes after metadata updates', async () => {
+      await db.addVector('metadata-vector', [1, 0], { label: 'old' });
+      await db.rebuildIndex();
+
+      await db.updateMetadata('metadata-vector', { label: 'new' });
+
+      const results = await db.search([1, 0], 1, { includeMetadata: true });
+      expect(results).toHaveLength(1);
+      expect(results[0]!.metadata).toEqual({ label: 'new' });
+    });
+
+    it('should force-rebuild cached indexes after batch vector updates', async () => {
+      await db.addVector('updated-vector', [1, 0], { label: 'old' });
+      await db.addVector('target-vector', [1, 0], { label: 'target' });
+      await db.rebuildIndex();
+
+      await db.updateBatch([
+        {
+          id: 'updated-vector',
+          metadata: { label: 'updated' },
+          vector: [0, 1],
+        },
+      ]);
+
+      const results = await db.search([1, 0], 2, {
+        includeMetadata: true,
+        includeVector: true,
+      });
+
+      expect(results[0]!.id).toBe('target-vector');
+
+      const updatedResult = results.find((result) => result.id === 'updated-vector');
+      expect(updatedResult?.metadata).toEqual({ label: 'updated' });
+      expect(Array.from(updatedResult!.vector!)).toEqual([0, 1]);
+    });
+
+    it('should reject invalid metadata in batch updates before writing', async () => {
+      await db.addVector('batch-validation', [1, 0], { version: 1 });
+
+      expect(
+        db.updateBatch([
+          {
+            id: 'batch-validation',
+            metadata: { '../secret': 'value' },
+          },
+        ]),
+      ).rejects.toThrow('Invalid metadata key: ../secret');
+
+      const stored = await db.getVector('batch-validation');
+      expect(stored?.metadata).toEqual({ version: 1 });
+    });
+  });
+
   describe('Storage Management', () => {
     it('should monitor storage quota', async () => {
       const quotaInfo = await db.getStorageQuota();

--- a/tests/integration/vector-database.integration.test.ts
+++ b/tests/integration/vector-database.integration.test.ts
@@ -1,6 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
 
-import { VectorDB, VectorFrankl } from '@/index.js';
+import { VectorDB, VectorFrankl, SearchEngine } from '@/index.js';
+import { VectorDatabase } from '@/core/database.js';
+import type { SearchOptions, StorageAdapter } from '@/core/types.js';
 import { cleanupIndexedDBMocks, setupIndexedDBMocks } from '../mocks/indexeddb-mock.js';
 
 describe('Vector Database Integration Tests', () => {
@@ -321,9 +323,41 @@ describe('Vector Database Integration Tests', () => {
   });
 
   describe('Indexed Mutation Consistency', () => {
+    const indexedMutationDBName = `${testDBName}-indexed-mutations`;
+
+    async function searchPersistedIndex(
+      queryVector: [number, number],
+      k: number,
+      options?: SearchOptions,
+    ) {
+      const internals = db as unknown as {
+        database: VectorDatabase | null;
+        storage: StorageAdapter;
+      };
+
+      if (!internals.database) {
+        throw new Error('Indexed mutation tests require default IndexedDB storage');
+      }
+
+      const searchEngine = new SearchEngine(internals.storage, 2, 'cosine', {
+        database: internals.database,
+        indexId: `${indexedMutationDBName}-main`,
+        useIndex: true,
+        useWorkers: false,
+      });
+
+      await searchEngine.rebuildIndex();
+
+      try {
+        return await searchEngine.search(new Float32Array(queryVector), k, options);
+      } finally {
+        await searchEngine.cleanup();
+      }
+    }
+
     beforeEach(async () => {
       await db.delete();
-      db = new VectorDB(`${testDBName}-indexed-mutations`, 2, {
+      db = new VectorDB(indexedMutationDBName, 2, {
         autoEviction: false,
         useIndex: true,
       });
@@ -343,6 +377,52 @@ describe('Vector Database Integration Tests', () => {
       expect(stats.vectorCount).toBe(0);
       expect(db.getIndexStats().nodeCount).toBe(0);
       expect(await db.search([1, 0], 5, { includeMetadata: true })).toEqual([]);
+
+      expect(await searchPersistedIndex([1, 0], 5, { includeMetadata: true })).toEqual(
+        [],
+      );
+    });
+
+    it('should delete persisted indexes when clearing while indexing is disabled', async () => {
+      await db.addVector('disabled-index-vector', [1, 0], { label: 'stale' });
+      await db.rebuildIndex();
+      await db.setIndexing(false);
+
+      await db.clear();
+      await db.setIndexing(true);
+
+      expect(db.getIndexStats().nodeCount).toBe(0);
+      expect(await db.search([1, 0], 5, { includeMetadata: true })).toEqual([]);
+      expect(await searchPersistedIndex([1, 0], 5, { includeMetadata: true })).toEqual(
+        [],
+      );
+    });
+
+    it('should delete persisted indexes when clearing from a non-indexed instance', async () => {
+      await db.addVector('recreated-index-vector', [1, 0], { label: 'stale' });
+      await db.rebuildIndex();
+      await db.close();
+
+      db = new VectorDB(indexedMutationDBName, 2, {
+        autoEviction: false,
+        useIndex: false,
+      });
+      await db.init();
+      await db.clear();
+      await db.close();
+
+      db = new VectorDB(indexedMutationDBName, 2, {
+        autoEviction: false,
+        useIndex: true,
+      });
+      await db.init();
+      await db.rebuildIndex();
+
+      expect(db.getIndexStats().nodeCount).toBe(0);
+      expect(await db.search([1, 0], 5, { includeMetadata: true })).toEqual([]);
+      expect(await searchPersistedIndex([1, 0], 5, { includeMetadata: true })).toEqual(
+        [],
+      );
     });
 
     it('should force-rebuild cached indexes after metadata updates', async () => {
@@ -354,6 +434,12 @@ describe('Vector Database Integration Tests', () => {
       const results = await db.search([1, 0], 1, { includeMetadata: true });
       expect(results).toHaveLength(1);
       expect(results[0]!.metadata).toEqual({ label: 'new' });
+
+      const persistedResults = await searchPersistedIndex([1, 0], 1, {
+        includeMetadata: true,
+      });
+      expect(persistedResults).toHaveLength(1);
+      expect(persistedResults[0]!.metadata).toEqual({ label: 'new' });
     });
 
     it('should force-rebuild cached indexes after batch vector updates', async () => {
@@ -379,22 +465,19 @@ describe('Vector Database Integration Tests', () => {
       const updatedResult = results.find((result) => result.id === 'updated-vector');
       expect(updatedResult?.metadata).toEqual({ label: 'updated' });
       expect(Array.from(updatedResult!.vector!)).toEqual([0, 1]);
-    });
 
-    it('should reject invalid metadata in batch updates before writing', async () => {
-      await db.addVector('batch-validation', [1, 0], { version: 1 });
+      const persistedResults = await searchPersistedIndex([1, 0], 2, {
+        includeMetadata: true,
+        includeVector: true,
+      });
 
-      expect(
-        db.updateBatch([
-          {
-            id: 'batch-validation',
-            metadata: { '../secret': 'value' },
-          },
-        ]),
-      ).rejects.toThrow('Invalid metadata key: ../secret');
+      expect(persistedResults[0]!.id).toBe('target-vector');
 
-      const stored = await db.getVector('batch-validation');
-      expect(stored?.metadata).toEqual({ version: 1 });
+      const persistedUpdatedResult = persistedResults.find(
+        (result) => result.id === 'updated-vector',
+      );
+      expect(persistedUpdatedResult?.metadata).toEqual({ label: 'updated' });
+      expect(Array.from(persistedUpdatedResult!.vector!)).toEqual([0, 1]);
     });
   });
 

--- a/tests/search/search-engine.test.ts
+++ b/tests/search/search-engine.test.ts
@@ -85,12 +85,31 @@ describe('SearchEngine', () => {
     });
 
     it('should not initialize GPU engine when navigator.gpu is unavailable', async () => {
-      const engine = new SearchEngine(await createMockStorage(), 4, 'cosine', {
-        useGPU: true,
+      const hadNavigator = 'navigator' in globalThis;
+      const previousNavigator = globalThis.navigator;
+
+      Object.defineProperty(globalThis, 'navigator', {
+        configurable: true,
+        value: {},
       });
-      const gpuStats = engine.getGPUStats();
-      expect(gpuStats.enabled).toBe(true);
-      expect(gpuStats.initialized).toBe(false);
+
+      try {
+        const engine = new SearchEngine(await createMockStorage(), 4, 'cosine', {
+          useGPU: true,
+        });
+        const gpuStats = engine.getGPUStats();
+        expect(gpuStats.enabled).toBe(true);
+        expect(gpuStats.initialized).toBe(false);
+      } finally {
+        if (hadNavigator) {
+          Object.defineProperty(globalThis, 'navigator', {
+            configurable: true,
+            value: previousNavigator,
+          });
+        } else {
+          Reflect.deleteProperty(globalThis, 'navigator');
+        }
+      }
     });
   });
 


### PR DESCRIPTION
## Summary
- delete persisted index snapshots when clearing a database
- force index rebuilds after metadata and batch mutations to bypass stale cache snapshots
- keep index persistence cleanup available even when a database instance has indexing disabled
- add indexed mutation consistency regressions that verify live and persisted index search behavior

## Committee Review
- TypeScript/correctness: approved after fixing non-indexed-instance persisted index cleanup
- Testing: approved
- Simplicity: approved
- Post-creation reviewer requested: @copilot

## Verification
- bun run format:check
- bun run lint
- bun run typecheck
- bun test tests/integration/vector-database.integration.test.ts -t "Indexed Mutation Consistency"
- bun run test
- bun run build
- git push pre-push hook: tests, build, secret scan, lint

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes indexed search correctness paths (clear, metadata, batch updates) and persistence cleanup; wrong behavior would surface as stale search results rather than silent data loss.
> 
> **Overview**
> Fixes **stale HNSW index snapshots** after vector mutations by keeping in-memory indexes, persisted IndexedDB snapshots, and storage in sync.
> 
> **`clear`** now wipes the active index and deletes the persisted snapshot via new **`clearIndex`** / **`IndexCache.deleteIndex`**, including when indexing is disabled on the instance—**`IndexCache`** is wired whenever a database is present, not only when HNSW is enabled.
> 
> **`updateMetadata`** and **`updateBatch`** trigger **`rebuildIndex({ loadFromCache: false })`** so rebuilds cannot short-circuit on outdated cached graphs; **`rebuildIndex`** gains an optional flag to skip cache load.
> 
> Adds **Indexed Mutation Consistency** integration coverage (clear paths, metadata/batch updates, live vs reloaded persisted search). Tweaks a **SearchEngine** GPU unit test to stub **`navigator`** without WebGPU.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f30fb464f8a5141adda72329c5dcc6f658777d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->