### PR TITLE
Implement shared memory batch search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `SharedMemoryManager.sharedMemoryBatchSearch()` now returns top-k results instead of an empty placeholder response
 - WebGPU `uncapturederror` event listener now removed in `cleanup()`, preventing listener accumulation across `init()` calls
 
 ### Added

--- a/src/workers/shared-memory.ts
+++ b/src/workers/shared-memory.ts
@@ -3,6 +3,7 @@
  */
 
 import type { DistanceMetric } from '../core/types.js';
+import { createDistanceCalculator } from '../search/distance-metrics.js';
 
 export interface SharedMemoryConfig {
   /** Maximum memory pool size in bytes */
@@ -493,20 +494,80 @@ export class SharedMemoryManager {
   }
 
   private async processChunkInWorkers(
-    _buffer: SharedArrayBuffer,
-    _layout: {
+    buffer: SharedArrayBuffer,
+    layout: {
       vectorsOffset: number;
       queriesOffset: number;
       vectorCount: number;
       queryCount: number;
     },
-    _k: number,
-    _metric: DistanceMetric,
+    k: number,
+    metric: DistanceMetric,
     _options: { topK?: number; threshold?: number },
   ): Promise<Array<Array<{ index: number; distance: number; score: number }>>> {
-    // This would delegate to the worker pool
-    // For now, return empty results as placeholder
-    return [];
+    const dimension = new DataView(buffer).getUint32(8, true);
+    const bytesPerVector = dimension * Float32Array.BYTES_PER_ELEMENT;
+    const calculator = createDistanceCalculator(metric);
+    const metricInfo = calculator.getMetricInfo();
+    const results: Array<Array<{ index: number; distance: number; score: number }>> = [];
+
+    for (let queryIndex = 0; queryIndex < layout.queryCount; queryIndex++) {
+      const queryView = new Float32Array(
+        buffer,
+        layout.queriesOffset + queryIndex * bytesPerVector,
+        dimension,
+      );
+      const query = metricInfo.requiresNormalized
+        ? this.normalizeVector(queryView)
+        : queryView;
+
+      const queryResults: Array<{ index: number; distance: number; score: number }> = [];
+
+      for (let vectorIndex = 0; vectorIndex < layout.vectorCount; vectorIndex++) {
+        const vectorView = new Float32Array(
+          buffer,
+          layout.vectorsOffset + vectorIndex * bytesPerVector,
+          dimension,
+        );
+        const vector = metricInfo.requiresNormalized
+          ? this.normalizeVector(vectorView)
+          : vectorView;
+        const distance = calculator.calculate(query, vector);
+
+        queryResults.push({
+          index: vectorIndex,
+          distance,
+          score: this.distanceToScore(distance, metric, dimension),
+        });
+      }
+
+      queryResults.sort((a, b) => a.distance - b.distance);
+      results.push(queryResults.slice(0, k));
+    }
+
+    return results;
+  }
+
+  private distanceToScore(
+    distance: number,
+    metric: DistanceMetric,
+    dimension: number,
+  ): number {
+    switch (metric) {
+      case 'cosine':
+        return 1 - distance / 2;
+      case 'dot':
+        return -distance;
+      case 'euclidean':
+      case 'manhattan':
+        return Math.exp(-distance);
+      case 'hamming':
+        return dimension > 0 ? 1 - distance / dimension : 1 / (1 + distance);
+      case 'jaccard':
+        return 1 - distance;
+      default:
+        return 1 / (1 + distance);
+    }
   }
 
   private updateStats(): void {

--- a/tests/workers/shared-memory.test.ts
+++ b/tests/workers/shared-memory.test.ts
@@ -313,5 +313,28 @@ describe('SharedMemoryManager', () => {
       expect(batch1!.vectorCount).toBe(1);
       expect(batch1!.queryCount).toBe(2);
     });
+
+    it('should return top results for shared memory batch search', async () => {
+      if (typeof SharedArrayBuffer === 'undefined') {
+        return;
+      }
+
+      const results = await manager.sharedMemoryBatchSearch(
+        [
+          new Float32Array([1, 0]),
+          new Float32Array([0, 1]),
+          new Float32Array([0.5, 0.5]),
+        ],
+        [new Float32Array([1, 0]), new Float32Array([0, 1])],
+        2,
+        'cosine',
+      );
+
+      expect(results).toHaveLength(2);
+      expect(results[0]).toHaveLength(2);
+      expect(results[0]![0]).toMatchObject({ index: 0, distance: 0, score: 1 });
+      expect(results[1]).toHaveLength(2);
+      expect(results[1]![0]).toMatchObject({ index: 1, distance: 0, score: 1 });
+    });
   });
 });


### PR DESCRIPTION
## Summary
- replace SharedMemoryManager.sharedMemoryBatchSearch() placeholder with top-k results
- reuse the existing distance calculator and score conversion semantics
- add regression coverage for shared-memory batch search
- record the behavior fix in CHANGELOG.md

## Committee Review
- TypeScript/correctness: approved
- Testing: approved
- Simplicity: approved
- Post-creation reviewer requested: @copilot

## Verification
- bun test tests/workers/shared-memory.test.ts tests/workers/worker-pool.test.ts
- bun run format:check
- bun run lint
- bun run typecheck
- bun run test
- bun run build
- git push pre-push hook: tests, build, secret scan, lint

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Fixes a broken search API but introduces brute-force distance work and score semantics that must stay aligned with other search paths; batch header layout must match buffer reads.
> 
> **Overview**
> **`SharedMemoryManager.sharedMemoryBatchSearch()`** now returns real **top-k** neighbors instead of an empty placeholder.
> 
> The chunk processor reads vectors and queries from the **`SharedArrayBuffer`** layout, runs distances via **`createDistanceCalculator`**, normalizes when the metric requires it, sorts by distance, and slices to **k**. A new **`distanceToScore`** helper maps distances to scores (cosine, dot, euclidean/manhattan, hamming, jaccard). **CHANGELOG** documents the fix, and a worker test asserts cosine batch search returns the expected nearest indices and scores.
> 
> Implementation still runs **in-process** in `processChunkInWorkers` (not the worker pool), despite the method name.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 64b01921d349cdf6191862ff169616b775682e8f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->