### PR TITLE
Verify npm package surface

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -91,6 +91,9 @@ jobs:
           fi
           echo "✅ Build output verified"
 
+      - name: Verify package surface
+        run: bun run scripts/check-package.ts
+
       - name: Install Playwright browsers
         run: bunx playwright install chromium --with-deps
 

--- a/.npmignore
+++ b/.npmignore
@@ -61,6 +61,7 @@ test-output/
 
 # Keep these files
 !dist/
+!dist/**
 !LICENSE
 !README.md
 !CHANGELOG.md

--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "prepack": "bun run build",
+    "package:check": "bun run build && bun run scripts/check-package.ts",
     "prepare": "husky",
     "prepublishOnly": "bun run lint && bun run typecheck && bun run test && bun run build",
     "start": "bun run dist/index.js",

--- a/scripts/check-package.ts
+++ b/scripts/check-package.ts
@@ -1,0 +1,33 @@
+const requiredPackageFiles = [
+  'package.json',
+  'README.md',
+  'LICENSE',
+  'CHANGELOG.md',
+  'dist/index.js',
+  'dist/index.d.ts',
+  'dist/cjs/index.js',
+  'dist/workers.js',
+  'dist/workers.d.ts',
+];
+
+const output = await Bun.$`npm pack --dry-run --json --ignore-scripts`.text();
+const [packageResult] = JSON.parse(output) as Array<{
+  files: Array<{ path: string }>;
+}>;
+
+if (!packageResult) {
+  throw new Error('npm pack did not return package metadata');
+}
+
+const packageFiles = new Set(packageResult.files.map((file) => file.path));
+const missingFiles = requiredPackageFiles.filter((file) => !packageFiles.has(file));
+
+if (missingFiles.length > 0) {
+  throw new Error(`Package is missing required files: ${missingFiles.join(', ')}`);
+}
+
+console.log(
+  `Package surface verified: ${packageResult.files.length} files include required entry points.`,
+);
+
+export {};

--- a/scripts/check-package.ts
+++ b/scripts/check-package.ts
@@ -1,14 +1,37 @@
+type PackageManifest = {
+  exports?: unknown;
+  main?: unknown;
+  types?: unknown;
+};
+
+const packageManifest = (await Bun.file('package.json').json()) as PackageManifest;
+
+const basePackageFiles = ['package.json', 'README.md', 'LICENSE', 'CHANGELOG.md'];
+
+const collectPackageTargets = (value: unknown): string[] => {
+  if (typeof value === 'string') {
+    return value.startsWith('./') ? [value.slice(2)] : [];
+  }
+
+  if (Array.isArray(value)) {
+    return value.flatMap((item) => collectPackageTargets(item));
+  }
+
+  if (value && typeof value === 'object') {
+    return Object.values(value).flatMap((item) => collectPackageTargets(item));
+  }
+
+  return [];
+};
+
 const requiredPackageFiles = [
-  'package.json',
-  'README.md',
-  'LICENSE',
-  'CHANGELOG.md',
-  'dist/index.js',
-  'dist/index.d.ts',
-  'dist/cjs/index.js',
-  'dist/workers.js',
-  'dist/workers.d.ts',
-];
+  ...new Set([
+    ...basePackageFiles,
+    ...collectPackageTargets(packageManifest.exports),
+    ...collectPackageTargets(packageManifest.main),
+    ...collectPackageTargets(packageManifest.types),
+  ]),
+].toSorted();
 
 const output = await Bun.$`npm pack --dry-run --json --ignore-scripts`.text();
 const [packageResult] = JSON.parse(output) as Array<{


### PR DESCRIPTION
## Summary
- verify packed npm tarballs include built entry points
- derive required package files from package.json exports/main/types
- include dist contents explicitly in npm ignore rules
- add CI package-surface verification after build

## Committee Review
- TypeScript/correctness: APPROVED
- Testing/CI coverage: APPROVED
- Simplicity/maintainability: APPROVED
- Post-creation reviewer requested: @copilot

## Verification
- bun run format:check
- bun run lint
- bun run typecheck
- bun run test
- bun run package:check
- git diff --check
- git push pre-push hook: tests, build, secret scan, lint

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Packaging and CI-only checks with no changes to library runtime behavior or consumer APIs.
> 
> **Overview**
> Adds **automated verification** that an `npm pack` tarball includes every file referenced by `package.json` (`exports`, `main`, `types`) plus standard metadata files.
> 
> A new `scripts/check-package.ts` walks those manifest paths and fails if `npm pack --dry-run` omits any of them. **CI** runs this after the build step, and a local **`package:check`** script runs build then the same check.
> 
> **.npmignore** is tightened so published tarballs explicitly keep all of `dist/**` (not only `dist/`), reducing the chance built entry points are accidentally excluded from npm.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7cd6a95d09ad5a8069ba91c3c2a074517ee65f2c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->