### PR TITLE
Make WASM acceleration availability honest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- WASM operations now report unavailable unless a real vector-operation backend is loaded, preserving SIMD/scalar fallback behavior instead of advertising placeholder acceleration
 - Replace all production `console.log`/`console.warn`/`console.error` calls with structured logger (`src/utilities/logger.ts`) so output can be suppressed
 - Convert HNSW `pruneConnections` lookup from `Array.includes()` (O(n)) to `Set.has()` (O(1))
 - Reject namespace names containing `-ns-` to prevent database name collisions
@@ -42,7 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Web Worker pool for parallel processing
 - SIMD acceleration for vector operations
 - WebGPU support for GPU-accelerated search
-- WebAssembly modules for high-performance operations
+- WebAssembly capability detection for optional acceleration
 - Comprehensive input validation and security features
 - ReDoS (Regular Expression Denial of Service) protection
 - Memory safety with configurable limits
@@ -57,7 +58,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Input validation for all user inputs
 - ReDoS protection with timeout and pattern validation
 - Memory limits to prevent exhaustion attacks
-- WASM module integrity verification
+- WebAssembly capability detection
 - Sanitized error messages to prevent information leakage
 
 ### Performance

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A high-performance vector database built on IndexedDB for browser-based storage,
 
 ## ✨ Why Vector Frankl is Awesome
 
-- **Unparalleled Performance:** Leveraging SIMD, WebAssembly, and WebGPU, Vector Frankl delivers near-native speed for vector operations, ensuring your AI features are responsive and efficient, even with large datasets.
+- **Unparalleled Performance:** Leveraging SIMD and WebGPU, Vector Frankl delivers fast vector operations, ensuring your AI features are responsive and efficient, even with large datasets.
 - **Runs Anywhere:** Defaults to IndexedDB in the browser for zero-config client-side AI, but pluggable storage adapters let you run the same API on top of SQLite, LevelDB, LMDB, Redis, S3, or the file system in Bun and Node.
 - **Rich Feature Set:** From advanced vector compression and multiple distance metrics to robust namespace management and comprehensive debugging tools, Vector Frankl provides everything you need to build sophisticated vector-based applications.
 - **Developer-Friendly:** With 100% TypeScript support, a clear API, and built-in performance monitoring, integrating and optimizing your AI workflows has never been easier.
@@ -50,7 +50,7 @@ The broader pattern here is moving vector search compute to the edge—the brows
 
 - 🏗️ **Namespace Management**: Isolated vector collections with independent configurations
 - 🎯 **Multiple Distance Metrics**: Cosine, Euclidean, Manhattan, Hamming, Jaccard, and custom metrics
-- 🚀 **Performance Optimizations**: SIMD operations, WebAssembly, and WebGPU acceleration
+- 🚀 **Performance Optimizations**: SIMD operations, WebGPU acceleration, and scalar fallbacks
 - 📦 **Vector Compression**: Scalar quantization, product quantization, and binary compression
 - 🔄 **Background Processing**: Web Workers for parallel operations
 
@@ -81,7 +81,7 @@ The broader pattern here is moving vector search compute to the edge—the brows
 
 - ⚡ **SIMD Operations**: Single Instruction, Multiple Data for vectorized computations
 - 🌐 **WebGPU Support**: GPU-accelerated search and mathematical operations
-- 🔧 **WebAssembly**: High-performance computing modules for critical operations
+- 🔧 **Acceleration Fallbacks**: Honest capability detection with SIMD/scalar fallbacks when optional acceleration is unavailable
 
 ## 📋 Prerequisites
 
@@ -277,7 +277,7 @@ const result = await manager.compress(vector);
 
 ### Performance Acceleration
 
-SIMD, WebAssembly, and WebGPU acceleration are used automatically by the search engine when available. You don't need to import or configure them directly — Vector Frankl detects browser capabilities and selects the fastest path.
+SIMD and WebGPU acceleration are used automatically by the search engine when available. You don't need to import or configure them directly — Vector Frankl detects browser capabilities and selects the fastest available path, falling back to scalar operations when acceleration is unavailable.
 
 #### WebGPU Acceleration
 
@@ -380,7 +380,7 @@ const searchWithProfiling = withProfiling('vector-search', (query, k) =>
 ├─────────────────────────────────────────────────────────────┤
 │  API Layer: VectorDB | VectorFrankl | Direct Modules       │
 ├─────────────────────────────────────────────────────────────┤
-│     Acceleration: SIMD | WebGPU | WebAssembly | Workers    │
+│        Acceleration: SIMD | WebGPU | Workers | Scalar      │
 ├─────────────────────────────────────────────────────────────┤
 │        Core: Search | Storage | Compression | Index        │
 ├─────────────────────────────────────────────────────────────┤
@@ -488,7 +488,7 @@ src/
 ├── types/              # Shared type definitions
 ├── utilities/          # Logging, file I/O, and helpers
 ├── vectors/            # Vector operations and formats
-├── wasm/               # WebAssembly modules
+├── wasm/               # WebAssembly capability detection and fallbacks
 ├── workers/            # Web Worker support
 └── index.ts            # Main exports
 
@@ -526,7 +526,7 @@ MIT License - see [LICENSE](LICENSE) for details.
 
 - IndexedDB for persistent browser storage
 - HNSW algorithm for efficient similarity search
-- WebGPU, WebAssembly, and SIMD for performance acceleration
+- WebGPU and SIMD for performance acceleration
 
 ## 📚 Related Projects
 

--- a/package.json
+++ b/package.json
@@ -15,8 +15,7 @@
     "machine-learning",
     "hnsw",
     "webgpu",
-    "simd",
-    "wasm"
+    "simd"
   ],
   "homepage": "https://github.com/stevekinney/vector-frankl#readme",
   "bugs": {

--- a/src/simd/simd-operations.ts
+++ b/src/simd/simd-operations.ts
@@ -2,6 +2,8 @@
  * SIMD-accelerated vector operations for high-performance computing
  */
 
+import { log } from '../utilities/logger.js';
+
 export interface SIMDConfig {
   /** Enable SIMD optimizations */
   enableSIMD?: boolean;
@@ -146,9 +148,10 @@ export class SIMDOperations {
 
     if (this.config.enableProfiling) {
       const endTime = performance.now();
-      console.debug(
-        `SIMD dot product: ${endTime - startTime}ms for ${a.length} elements`,
-      );
+      log.debug('SIMD dot product completed', {
+        durationMilliseconds: endTime - startTime,
+        elementCount: a.length,
+      });
     }
 
     return result;
@@ -171,9 +174,10 @@ export class SIMDOperations {
 
     if (this.config.enableProfiling) {
       const endTime = performance.now();
-      console.debug(
-        `SIMD Euclidean distance: ${endTime - startTime}ms for ${a.length} elements`,
-      );
+      log.debug('SIMD Euclidean distance completed', {
+        durationMilliseconds: endTime - startTime,
+        elementCount: a.length,
+      });
     }
 
     return result;
@@ -196,9 +200,10 @@ export class SIMDOperations {
 
     if (this.config.enableProfiling) {
       const endTime = performance.now();
-      console.debug(
-        `SIMD Manhattan distance: ${endTime - startTime}ms for ${a.length} elements`,
-      );
+      log.debug('SIMD Manhattan distance completed', {
+        durationMilliseconds: endTime - startTime,
+        elementCount: a.length,
+      });
     }
 
     return result;
@@ -217,9 +222,10 @@ export class SIMDOperations {
 
     if (this.config.enableProfiling) {
       const endTime = performance.now();
-      console.debug(
-        `SIMD normalize: ${endTime - startTime}ms for ${vector.length} elements`,
-      );
+      log.debug('SIMD normalize completed', {
+        durationMilliseconds: endTime - startTime,
+        elementCount: vector.length,
+      });
     }
 
     return result;

--- a/src/vectors/operations.ts
+++ b/src/vectors/operations.ts
@@ -5,7 +5,7 @@ import { WASMOperations } from '../wasm/wasm-operations.js';
 import { VectorFormatHandler } from './formats.js';
 
 /**
- * Vector mathematical operations with WebAssembly and SIMD acceleration
+ * Vector mathematical operations with optional WebAssembly and SIMD acceleration.
  */
 export class VectorOperations {
   private static simdOps = new SIMDOperations();
@@ -286,7 +286,7 @@ export class VectorOperations {
       throw new DimensionMismatchError(vectorA.length, vectorB.length);
     }
 
-    // Three-tier optimization: WASM → SIMD → Scalar
+    // Use WASM only when a real backend is available; otherwise fall back.
     if (vectorA.length >= this.wasmThreshold && this.isWasmInitialized) {
       try {
         return await this.wasmOps.vectorSubtract(vectorA, vectorB);
@@ -312,7 +312,7 @@ export class VectorOperations {
    * Scale a vector by a scalar
    */
   static async scale(vector: Float32Array, scalar: number): Promise<Float32Array> {
-    // Three-tier optimization: WASM → SIMD → Scalar
+    // Use WASM only when a real backend is available; otherwise fall back.
     if (vector.length >= this.wasmThreshold && this.isWasmInitialized) {
       try {
         return await this.wasmOps.scalarMultiply(vector, scalar);

--- a/src/wasm/wasm-manager.ts
+++ b/src/wasm/wasm-manager.ts
@@ -1,5 +1,5 @@
 /**
- * WebAssembly manager for high-performance vector operations
+ * WebAssembly manager for optional vector-operation backends.
  */
 
 import { log } from '../utilities/logger.js';
@@ -13,7 +13,7 @@ export interface WASMConfig {
   enableProfiling?: boolean;
   /** Maximum memory allocation in bytes */
   maxMemory?: number;
-  /** WASM module path */
+  /** Reserved for a future compiled WASM module path */
   modulePath?: string;
 }
 
@@ -50,12 +50,15 @@ export interface WASMPerformanceStats {
 }
 
 /**
- * High-performance WebAssembly operations manager
+ * WebAssembly operations manager.
+ *
+ * The package does not currently bundle a compiled vector-operation module. Keep WASM
+ * unavailable unless a real backend is wired in so callers fall back to SIMD/scalar
+ * implementations instead of relying on placeholder exports.
  */
 export class WASMManager {
   private config: Required<WASMConfig>;
   private capabilities: WASMCapabilities;
-  private wasmModule: WebAssembly.Module | null = null;
   private wasmInstance: WebAssembly.Instance | null = null;
   private memory: WebAssembly.Memory | null = null;
   private isInitialized = false;
@@ -150,71 +153,17 @@ export class WASMManager {
    * Initialize WebAssembly module with security validation
    */
   async init(): Promise<void> {
-    if (this.isInitialized || !this.capabilities.supported) {
+    if (this.isInitialized || !this.config.enableWASM || !this.capabilities.supported) {
       return;
     }
 
     try {
-      // For demonstration purposes, we'll create a mock WASM implementation
-      // In production, you would load a real compiled WASM module from a .wasm file
-      if (this.capabilities.supported) {
-        // Use the simplest possible valid WASM module
-        const wasmCode = new Uint8Array([
-          0x00,
-          0x61,
-          0x73,
-          0x6d, // magic
-          0x01,
-          0x00,
-          0x00,
-          0x00, // version
-        ]);
-
-        try {
-          // Validate WASM module before compilation
-          await this.validateWASMModule(wasmCode);
-
-          this.wasmModule = await WebAssembly.compile(wasmCode);
-          this.wasmInstance = await WebAssembly.instantiate(this.wasmModule, {
-            // Provide secure import object with limited capabilities
-            env: {
-              // Only allow necessary imports
-              ...(this.memory && { memory: this.memory }),
-              console_log: (msg: number) => {
-                // Secure logging with message length limit
-                if (msg < 1000) {
-                  log.debug(`WASM: ${msg}`);
-                }
-              },
-            },
-          });
-        } catch (error) {
-          // If even the minimal module fails, we'll work without real WASM
-          log.warn('WASM module validation or compilation failed', {
-            error: error instanceof Error ? error.message : String(error),
-          });
-        }
-
-        // Create a wrapper instance with mock functions for demonstration
-        // In production, you would have real WASM exports
-        this.wasmInstance = {
-          exports: {
-            dotProduct: (_ptr: number, _length: number) => 0.0,
-            magnitude: (_length: number) => 1.0,
-            noop: () => {},
-          },
-        } as WebAssembly.Instance;
-
-        this.isInitialized = true;
-
-        if (this.config.enableProfiling) {
-          log.debug('WebAssembly module initialized successfully (demo mode)');
-          log.debug(
-            'WASM capabilities',
-            this.capabilities as unknown as Record<string, unknown>,
-          );
-        }
+      if (!this.config.modulePath) {
+        log.debug('No WebAssembly module configured; using SIMD/scalar fallbacks');
+        return;
       }
+
+      log.warn('External WebAssembly modules are not enabled in this build');
     } catch (error) {
       log.warn('Failed to initialize WebAssembly', {
         error: error instanceof Error ? error.message : String(error),
@@ -222,106 +171,6 @@ export class WASMManager {
       this.capabilities.supported = false;
       throw error;
     }
-  }
-
-  /**
-   * Validate WASM module for security and integrity
-   */
-  private async validateWASMModule(wasmCode: Uint8Array): Promise<void> {
-    // Basic validation checks
-    if (!wasmCode || wasmCode.length === 0) {
-      throw new Error('Empty WASM module');
-    }
-
-    // Check minimum size for a valid WASM module
-    if (wasmCode.length < 8) {
-      throw new Error('WASM module too small to be valid');
-    }
-
-    // Verify WASM magic number and version
-    const magic = new Uint8Array(wasmCode.slice(0, 4));
-    const version = new Uint8Array(wasmCode.slice(4, 8));
-
-    const expectedMagic = new Uint8Array([0x00, 0x61, 0x73, 0x6d]);
-    const expectedVersion = new Uint8Array([0x01, 0x00, 0x00, 0x00]);
-
-    if (!this.arrayEquals(magic, expectedMagic)) {
-      throw new Error('Invalid WASM magic number');
-    }
-
-    if (!this.arrayEquals(version, expectedVersion)) {
-      throw new Error('Unsupported WASM version');
-    }
-
-    // Check module size limits to prevent memory exhaustion
-    const MAX_MODULE_SIZE = 10 * 1024 * 1024; // 10MB max
-    if (wasmCode.length > MAX_MODULE_SIZE) {
-      throw new Error(
-        `WASM module too large: ${wasmCode.length} bytes exceeds maximum ${MAX_MODULE_SIZE} bytes`,
-      );
-    }
-
-    // Validate module using WebAssembly.validate
-    if (!WebAssembly.validate(wasmCode)) {
-      throw new Error('Invalid WASM module structure');
-    }
-
-    // Additional security checks for suspicious patterns
-    await this.checkForSuspiciousPatterns(wasmCode);
-  }
-
-  /**
-   * Check for suspicious patterns in WASM bytecode
-   */
-  private async checkForSuspiciousPatterns(wasmCode: Uint8Array): Promise<void> {
-    // Check for excessive import sections (could indicate malicious behavior)
-    let importSectionCount = 0;
-    let currentPos = 8; // Skip magic and version
-
-    while (currentPos < wasmCode.length) {
-      if (currentPos + 1 >= wasmCode.length) break;
-
-      const sectionId = wasmCode[currentPos];
-      currentPos++;
-
-      if (currentPos >= wasmCode.length) break;
-
-      // Read section size (LEB128 encoded)
-      let sectionSize = 0;
-      let shift = 0;
-      let byte;
-
-      do {
-        if (currentPos >= wasmCode.length) break;
-        byte = wasmCode[currentPos++];
-        if (byte !== undefined) {
-          sectionSize |= (byte & 0x7f) << shift;
-          shift += 7;
-        }
-      } while (byte !== undefined && byte & 0x80 && shift < 35);
-
-      if (sectionId === 2) {
-        // Import section
-        importSectionCount++;
-        if (importSectionCount > 10) {
-          throw new Error('Suspicious: Too many import sections in WASM module');
-        }
-      }
-
-      // Skip section content
-      currentPos += sectionSize;
-    }
-  }
-
-  /**
-   * Compare two Uint8Arrays for equality
-   */
-  private arrayEquals(a: Uint8Array, b: Uint8Array): boolean {
-    if (a.length !== b.length) return false;
-    for (let i = 0; i < a.length; i++) {
-      if (a[i] !== b[i]) return false;
-    }
-    return true;
   }
 
   /**
@@ -392,6 +241,10 @@ export class WASMManager {
    * Compute dot product using WebAssembly
    */
   async dotProduct(vectorA: Float32Array, vectorB: Float32Array): Promise<number> {
+    if (vectorA.length !== vectorB.length) {
+      throw new Error('Vector dimensions must match');
+    }
+
     if (!this.isAvailable() || !this.wasmInstance) {
       throw new Error('WebAssembly not available');
     }
@@ -399,21 +252,14 @@ export class WASMManager {
     const startTime = this.config.enableProfiling ? performance.now() : 0;
 
     try {
-      // For the simplified WASM module, we'll compute in JavaScript
-      // but demonstrate the WASM integration pattern
       const exports = this.wasmInstance.exports as {
         dotProduct: (ptr: number, length: number) => number;
         magnitude: (length: number) => number;
         noop: () => void;
       };
 
-      // Call the WASM function (currently returns 0.0 in our simplified module)
-      // In a real implementation, this would do the actual computation
-      // Call the WASM function for integration purposes
       exports.dotProduct(0, vectorA.length);
 
-      // For demonstration, compute the actual result in JavaScript
-      // In production, the WASM module would do this computation
       let result = 0;
       for (let i = 0; i < vectorA.length; i++) {
         result += (vectorA[i] ?? 0) * (vectorB[i] ?? 0);
@@ -421,9 +267,10 @@ export class WASMManager {
 
       if (this.config.enableProfiling) {
         const endTime = performance.now();
-        console.debug(
-          `WASM dot product: ${endTime - startTime}ms for ${vectorA.length} elements`,
-        );
+        log.debug('WASM dot product completed', {
+          durationMilliseconds: endTime - startTime,
+          elementCount: vectorA.length,
+        });
       }
 
       return result;
@@ -449,12 +296,8 @@ export class WASMManager {
         noop: () => void;
       };
 
-      // Call the WASM function (currently returns 1.0 in our simplified module)
-      // Call the WASM function for integration purposes
       exports.magnitude(vector.length);
 
-      // For demonstration, compute the actual result in JavaScript
-      // In production, the WASM module would do this computation
       let sum = 0;
       for (let i = 0; i < vector.length; i++) {
         sum += (vector[i] ?? 0) * (vector[i] ?? 0);
@@ -463,9 +306,10 @@ export class WASMManager {
 
       if (this.config.enableProfiling) {
         const endTime = performance.now();
-        console.debug(
-          `WASM magnitude: ${endTime - startTime}ms for ${vector.length} elements`,
-        );
+        log.debug('WASM magnitude completed', {
+          durationMilliseconds: endTime - startTime,
+          elementCount: vector.length,
+        });
       }
 
       return result;
@@ -478,6 +322,10 @@ export class WASMManager {
    * Vector addition using WebAssembly
    */
   async vectorAdd(vectorA: Float32Array, vectorB: Float32Array): Promise<Float32Array> {
+    if (vectorA.length !== vectorB.length) {
+      throw new Error('Vector dimensions must match');
+    }
+
     if (!this.isAvailable() || !this.wasmInstance) {
       throw new Error('WebAssembly not available');
     }
@@ -491,11 +339,8 @@ export class WASMManager {
         noop: () => void;
       };
 
-      // Call the WASM noop function to demonstrate integration
       exports.noop();
 
-      // For demonstration, compute the actual result in JavaScript
-      // In production, the WASM module would do this computation
       const result = new Float32Array(vectorA.length);
       for (let i = 0; i < vectorA.length; i++) {
         result[i] = (vectorA[i] ?? 0) + (vectorB[i] ?? 0);
@@ -503,9 +348,10 @@ export class WASMManager {
 
       if (this.config.enableProfiling) {
         const endTime = performance.now();
-        console.debug(
-          `WASM vector add: ${endTime - startTime}ms for ${vectorA.length} elements`,
-        );
+        log.debug('WASM vector add completed', {
+          durationMilliseconds: endTime - startTime,
+          elementCount: vectorA.length,
+        });
       }
 
       return result;
@@ -546,14 +392,20 @@ export class WASMManager {
 
     // Benchmark JavaScript
     const jsStart = performance.now();
+    let javascriptChecksum = 0;
     for (let i = 0; i < iterations; i++) {
-      let _sum = 0;
+      let sum = 0;
       for (let j = 0; j < vectorA.length; j++) {
-        _sum += (vectorA[j] ?? 0) * (vectorB[j] ?? 0);
+        sum += (vectorA[j] ?? 0) * (vectorB[j] ?? 0);
       }
+      javascriptChecksum += sum;
     }
     const jsEnd = performance.now();
     const jsTime = jsEnd - jsStart;
+
+    if (!Number.isFinite(javascriptChecksum)) {
+      throw new Error('JavaScript benchmark produced a non-finite checksum');
+    }
 
     const dataSize = vectorLength * 4 * 2; // 2 vectors * 4 bytes per float
     const totalData = (dataSize * iterations) / (1024 * 1024); // MB
@@ -581,7 +433,6 @@ export class WASMManager {
    * Cleanup WebAssembly resources
    */
   async cleanup(): Promise<void> {
-    this.wasmModule = null;
     this.wasmInstance = null;
     this.memory = null;
     this.isInitialized = false;

--- a/src/workers/shared-memory.ts
+++ b/src/workers/shared-memory.ts
@@ -4,6 +4,7 @@
 
 import type { DistanceMetric } from '../core/types.js';
 import { createDistanceCalculator } from '../search/distance-metrics.js';
+import { log } from '../utilities/logger.js';
 
 export interface SharedMemoryConfig {
   /** Maximum memory pool size in bytes */
@@ -396,7 +397,7 @@ export class SharedMemoryManager {
 
     const removedCount = initialLength - this.memoryPool.length;
     if (removedCount > 0 && this.config.enableStats) {
-      console.debug(`Cleaned up ${removedCount} memory blocks`);
+      log.debug('Cleaned up shared memory blocks', { removedCount });
     }
 
     this.updateStats();

--- a/tests/wasm/wasm-manager.test.ts
+++ b/tests/wasm/wasm-manager.test.ts
@@ -27,13 +27,13 @@ describe('WASMManager', () => {
       expect(capabilities.performance).toBeDefined();
     });
 
-    it('should initialize WebAssembly module if supported', async () => {
-      if (wasmManager.getCapabilities().supported) {
-        await wasmManager.init();
-        expect(wasmManager.isAvailable()).toBe(true);
-      } else {
-        console.log('WebAssembly not supported in this environment, skipping');
-      }
+    it('should not report vector-operation availability without a real module', async () => {
+      await wasmManager.init();
+
+      expect(wasmManager.getCapabilities().supported).toBe(
+        typeof WebAssembly !== 'undefined',
+      );
+      expect(wasmManager.isAvailable()).toBe(false);
     });
   });
 
@@ -72,17 +72,28 @@ describe('WASMManager', () => {
     const testVectorA = new Float32Array([1, 2, 3, 4]);
     const testVectorB = new Float32Array([5, 6, 7, 8]);
 
+    it('should reject vector operations when no real WASM backend is loaded', async () => {
+      await wasmManager.init();
+
+      expect(wasmManager.dotProduct(testVectorA, testVectorB)).rejects.toThrow(
+        'WebAssembly not available',
+      );
+      expect(wasmManager.magnitude(testVectorA)).rejects.toThrow(
+        'WebAssembly not available',
+      );
+      expect(wasmManager.vectorAdd(testVectorA, testVectorB)).rejects.toThrow(
+        'WebAssembly not available',
+      );
+    });
+
     it('should compute dot product with WebAssembly', async () => {
       if (!wasmManager.isAvailable()) {
         console.log('WASM not available, skipping operation tests');
         return;
       }
 
-      // The inline WASM module may return simplified results
-      // This test verifies the operation doesn't crash
       const result = await wasmManager.dotProduct(testVectorA, testVectorB);
-      expect(typeof result).toBe('number');
-      expect(isFinite(result)).toBe(true);
+      expect(result).toBe(70);
     });
 
     it('should compute magnitude with WebAssembly', async () => {
@@ -111,16 +122,12 @@ describe('WASMManager', () => {
         return;
       }
 
-      // Test with mismatched vector lengths (if supported by implementation)
       const vectorA = new Float32Array([1, 2]);
       const vectorB = new Float32Array([1, 2, 3]);
 
-      try {
-        await wasmManager.dotProduct(vectorA, vectorB);
-        // If it doesn't throw, that's fine too - depends on WASM implementation
-      } catch (error) {
-        expect(error).toBeInstanceOf(Error);
-      }
+      expect(wasmManager.dotProduct(vectorA, vectorB)).rejects.toThrow(
+        'Vector dimensions must match',
+      );
     });
   });
 
@@ -178,10 +185,8 @@ describe('WASMManager', () => {
     it('should handle cleanup gracefully', async () => {
       const tempWasm = new WASMManager();
 
-      if (tempWasm.getCapabilities().supported) {
-        await tempWasm.init();
-        expect(tempWasm.isAvailable()).toBe(true);
-      }
+      await tempWasm.init();
+      expect(tempWasm.isAvailable()).toBe(false);
 
       await tempWasm.cleanup();
       expect(tempWasm.isAvailable()).toBe(false);
@@ -283,7 +288,6 @@ describe('WASMManager', () => {
         const result = await wasmManager.dotProduct(specialA, specialB);
         expect(typeof result).toBe('number');
       } catch (error) {
-        // May throw depending on how WASM handles special values
         expect(error).toBeInstanceOf(Error);
       }
     });

--- a/tests/wasm/wasm-operations.test.ts
+++ b/tests/wasm/wasm-operations.test.ts
@@ -339,8 +339,7 @@ describe('WASMOperations', () => {
       await noWasmOps.init();
 
       const capabilities = noWasmOps.getCapabilities();
-      // Note: capabilities may still show WASM as available if the environment supports it
-      // but the operations will use SIMD/scalar fallback
+      expect(capabilities.wasmAvailable).toBe(false);
       expect(capabilities.scalarAvailable).toBe(true);
 
       // Operations should still work


### PR DESCRIPTION
## Summary
- stop reporting WASM vector acceleration as available without a real backend
- preserve SIMD/scalar fallback behavior in higher-level operations
- replace remaining production console.debug calls with structured logging
- align README, changelog, and package keywords with shipped acceleration behavior

## Committee Review
- TypeScript/correctness: APPROVED
- Testing/CI coverage: APPROVED
- Simplicity/maintainability: APPROVED
- Post-creation reviewer requested: @copilot

## Verification
- bun run format:check
- bun run lint
- bun run typecheck
- bun run test
- bun run package:check
- git diff --check
- git push pre-push hook: tests, build, secret scan, lint

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes hot-path acceleration selection in `VectorOperations` and public WASM availability semantics; behavior shifts from silent JS-in-WASM to explicit unavailability, which is intentional but affects callers that assumed WASM was on after `init()`.
> 
> **Overview**
> **WASM acceleration is no longer advertised as ready** when there is no bundled vector-operation module. `WASMManager.init()` skips the old minimal/mock module and placeholder exports, so `isAvailable()` stays false unless a real backend is wired via `modulePath` (not enabled in this build). Higher-level `VectorOperations` still only uses WASM when initialized; otherwise SIMD/scalar paths apply unchanged.
> 
> **Docs and packaging** now describe SIMD/WebGPU plus honest fallbacks instead of shipped WASM modules (`README`, `CHANGELOG`, removed `wasm` keyword).
> 
> **Logging**: remaining production `console.debug` in SIMD profiling, WASM profiling, and shared-memory cleanup now use the structured `log` helper.
> 
> **Tests** expect unavailable WASM by default, reject operations without a backend, and assert dimension mismatches; `WASMOperations` with WASM disabled reports `wasmAvailable: false`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b7667c97cf5fce4cedcd1412e73e3cb2a6c24d4e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->