### PR TITLE
Publish documented adapter subpaths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Published `vector-frankl/adapters/*` subpath exports for storage adapters documented in the README
 - Unit tests for distance metrics, search engine, input validator, eviction policies, quota monitor, and index persistence
 
 ### Removed

--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ await db.init();
 
 ```typescript
 // SQLite (Bun runtime only)
-import { SQLiteStorageAdapter } from 'vector-frankl/src/storage/adapters/sqlite-adapter';
+import { SQLiteStorageAdapter } from 'vector-frankl/adapters/sqlite';
 
 const sqlite = new SQLiteStorageAdapter({ filename: './vectors.db' });
 const db = new VectorDB('my-vectors', 384, { storage: sqlite });
@@ -221,7 +221,7 @@ await db.init();
 ```typescript
 // Use a factory so each namespace gets its own storage
 import { VectorFrankl } from 'vector-frankl';
-import { SQLiteStorageAdapter } from 'vector-frankl/src/storage/adapters/sqlite-adapter';
+import { SQLiteStorageAdapter } from 'vector-frankl/adapters/sqlite';
 
 const frankl = new VectorFrankl('my-vectors', {
   defaultDimension: 384,

--- a/package.json
+++ b/package.json
@@ -127,11 +127,11 @@
   ],
   "scripts": {
     "build": "bun run build:clean && bun run build:types && bun run build:js && bun run build:cjs && bun run build:adapters",
-    "build:adapters": "bun build --target=bun --root=src/storage/adapters --outdir=dist/storage/adapters --format=esm --packages=external --sourcemap=external ./src/storage/adapters/chrome-storage-adapter.ts ./src/storage/adapters/file-system-adapter.ts ./src/storage/adapters/indexed-database-adapter.ts ./src/storage/adapters/level-adapter.ts ./src/storage/adapters/lmdb-adapter.ts ./src/storage/adapters/memory-adapter.ts ./src/storage/adapters/opfs-adapter.ts ./src/storage/adapters/redis-adapter.ts ./src/storage/adapters/s3-adapter.ts ./src/storage/adapters/sqlite-adapter.ts",
+    "build:adapters": "bun build --target=bun --root=src/storage/adapters --outdir=dist/storage/adapters --format=esm --sourcemap=external ./src/storage/adapters/chrome-storage-adapter.ts ./src/storage/adapters/file-system-adapter.ts ./src/storage/adapters/indexed-database-adapter.ts ./src/storage/adapters/level-adapter.ts ./src/storage/adapters/lmdb-adapter.ts ./src/storage/adapters/memory-adapter.ts ./src/storage/adapters/opfs-adapter.ts ./src/storage/adapters/redis-adapter.ts ./src/storage/adapters/s3-adapter.ts ./src/storage/adapters/sqlite-adapter.ts",
     "build:cjs": "bun build --target=browser --outdir=dist/cjs --format=cjs --minify --sourcemap=external ./src/index.ts ./src/gpu.ts ./src/workers.ts ./src/debug.ts ./src/benchmarks.ts ./src/compression.ts",
     "build:clean": "rm -rf dist",
     "build:js": "bun build --target=browser --outdir=dist --format=esm --minify --sourcemap=external ./src/index.ts ./src/gpu.ts ./src/workers.ts ./src/debug.ts ./src/benchmarks.ts ./src/compression.ts",
-    "build:types": "tsc -p tsconfig.build.json",
+    "build:types": "tsc -p tsconfig.build.json && bun run scripts/rewrite-declaration-imports.ts",
     "check:env": "bun run scripts/check-environment.ts",
     "clean": "bun run scripts/clean.ts",
     "dev": "bun --watch run src/index.ts",

--- a/package.json
+++ b/package.json
@@ -65,6 +65,56 @@
       "import": "./dist/compression.js",
       "require": "./dist/cjs/compression.js",
       "default": "./dist/compression.js"
+    },
+    "./adapters/chrome-storage": {
+      "types": "./dist/storage/adapters/chrome-storage-adapter.d.ts",
+      "import": "./dist/storage/adapters/chrome-storage-adapter.js",
+      "default": "./dist/storage/adapters/chrome-storage-adapter.js"
+    },
+    "./adapters/file-system": {
+      "types": "./dist/storage/adapters/file-system-adapter.d.ts",
+      "import": "./dist/storage/adapters/file-system-adapter.js",
+      "default": "./dist/storage/adapters/file-system-adapter.js"
+    },
+    "./adapters/indexed-database": {
+      "types": "./dist/storage/adapters/indexed-database-adapter.d.ts",
+      "import": "./dist/storage/adapters/indexed-database-adapter.js",
+      "default": "./dist/storage/adapters/indexed-database-adapter.js"
+    },
+    "./adapters/level": {
+      "types": "./dist/storage/adapters/level-adapter.d.ts",
+      "import": "./dist/storage/adapters/level-adapter.js",
+      "default": "./dist/storage/adapters/level-adapter.js"
+    },
+    "./adapters/lmdb": {
+      "types": "./dist/storage/adapters/lmdb-adapter.d.ts",
+      "import": "./dist/storage/adapters/lmdb-adapter.js",
+      "default": "./dist/storage/adapters/lmdb-adapter.js"
+    },
+    "./adapters/memory": {
+      "types": "./dist/storage/adapters/memory-adapter.d.ts",
+      "import": "./dist/storage/adapters/memory-adapter.js",
+      "default": "./dist/storage/adapters/memory-adapter.js"
+    },
+    "./adapters/opfs": {
+      "types": "./dist/storage/adapters/opfs-adapter.d.ts",
+      "import": "./dist/storage/adapters/opfs-adapter.js",
+      "default": "./dist/storage/adapters/opfs-adapter.js"
+    },
+    "./adapters/redis": {
+      "types": "./dist/storage/adapters/redis-adapter.d.ts",
+      "import": "./dist/storage/adapters/redis-adapter.js",
+      "default": "./dist/storage/adapters/redis-adapter.js"
+    },
+    "./adapters/s3": {
+      "types": "./dist/storage/adapters/s3-adapter.d.ts",
+      "import": "./dist/storage/adapters/s3-adapter.js",
+      "default": "./dist/storage/adapters/s3-adapter.js"
+    },
+    "./adapters/sqlite": {
+      "types": "./dist/storage/adapters/sqlite-adapter.d.ts",
+      "import": "./dist/storage/adapters/sqlite-adapter.js",
+      "default": "./dist/storage/adapters/sqlite-adapter.js"
     }
   },
   "main": "./dist/index.js",
@@ -76,7 +126,8 @@
     "CHANGELOG.md"
   ],
   "scripts": {
-    "build": "bun run build:clean && bun run build:types && bun run build:js && bun run build:cjs",
+    "build": "bun run build:clean && bun run build:types && bun run build:js && bun run build:cjs && bun run build:adapters",
+    "build:adapters": "bun build --target=bun --root=src/storage/adapters --outdir=dist/storage/adapters --format=esm --packages=external --sourcemap=external ./src/storage/adapters/chrome-storage-adapter.ts ./src/storage/adapters/file-system-adapter.ts ./src/storage/adapters/indexed-database-adapter.ts ./src/storage/adapters/level-adapter.ts ./src/storage/adapters/lmdb-adapter.ts ./src/storage/adapters/memory-adapter.ts ./src/storage/adapters/opfs-adapter.ts ./src/storage/adapters/redis-adapter.ts ./src/storage/adapters/s3-adapter.ts ./src/storage/adapters/sqlite-adapter.ts",
     "build:cjs": "bun build --target=browser --outdir=dist/cjs --format=cjs --minify --sourcemap=external ./src/index.ts ./src/gpu.ts ./src/workers.ts ./src/debug.ts ./src/benchmarks.ts ./src/compression.ts",
     "build:clean": "rm -rf dist",
     "build:js": "bun build --target=browser --outdir=dist --format=esm --minify --sourcemap=external ./src/index.ts ./src/gpu.ts ./src/workers.ts ./src/debug.ts ./src/benchmarks.ts ./src/compression.ts",

--- a/scripts/rewrite-declaration-imports.ts
+++ b/scripts/rewrite-declaration-imports.ts
@@ -1,0 +1,48 @@
+import { readdir, readFile, writeFile } from 'node:fs/promises';
+import { dirname, relative, resolve, sep } from 'node:path';
+
+const declarationsRoot = resolve('dist');
+
+async function* walkDeclarationFiles(directory: string): AsyncGenerator<string> {
+  for (const entry of await readdir(directory, { withFileTypes: true })) {
+    const path = resolve(directory, entry.name);
+
+    if (entry.isDirectory()) {
+      yield* walkDeclarationFiles(path);
+      continue;
+    }
+
+    if (entry.isFile() && path.endsWith('.d.ts')) {
+      yield path;
+    }
+  }
+}
+
+function toImportSpecifier(fromFile: string, aliasTarget: string): string {
+  const target = resolve(declarationsRoot, aliasTarget);
+  let specifier = relative(dirname(fromFile), target).split(sep).join('/');
+
+  if (!specifier.startsWith('.')) {
+    specifier = `./${specifier}`;
+  }
+
+  return specifier;
+}
+
+for await (const file of walkDeclarationFiles(declarationsRoot)) {
+  const content = await readFile(file, 'utf8');
+  const rewritten = content.replace(
+    /(["'])@\/([^"']+)\1/g,
+    (match: string, quote: string, aliasTarget: string) => {
+      if (aliasTarget.includes('*')) {
+        return match;
+      }
+
+      return `${quote}${toImportSpecifier(file, aliasTarget)}${quote}`;
+    },
+  );
+
+  if (rewritten !== content) {
+    await writeFile(file, rewritten);
+  }
+}

--- a/src/core/database.ts
+++ b/src/core/database.ts
@@ -4,7 +4,13 @@ import {
   DatabaseInitializationError,
   TransactionError,
 } from './errors.js';
-import type { DatabaseConfig } from './types.js';
+import type {
+  DatabaseConfig,
+  IndexedDatabaseInfo,
+  IndexedDatabaseUpgradeDatabase,
+  IndexedDatabaseTransaction,
+  IndexedDatabaseTransactionMode,
+} from './types.js';
 
 /**
  * Core database class for managing IndexedDB connections and operations
@@ -13,9 +19,7 @@ export class VectorDatabase {
   private database: IDBDatabase | null = null;
   private readonly name: string;
   private readonly version: number;
-  private readonly onUpgrade:
-    | ((database: IDBDatabase, oldVersion: number) => void)
-    | undefined;
+  private readonly onUpgrade: DatabaseConfig['onUpgrade'];
   private initializationPromise: Promise<void> | null = null;
 
   /**
@@ -96,10 +100,11 @@ export class VectorDatabase {
 
       request.onupgradeneeded = (event) => {
         const database = (event.target as IDBOpenDBRequest).result;
+        const upgradeDatabase = database as unknown as IndexedDatabaseUpgradeDatabase;
         if (this.onUpgrade) {
-          this.onUpgrade(database, event.oldVersion);
+          this.onUpgrade(upgradeDatabase, event.oldVersion);
         } else {
-          this.createSchema(database, event.oldVersion);
+          this.createSchema(upgradeDatabase, event.oldVersion);
         }
       };
 
@@ -116,7 +121,10 @@ export class VectorDatabase {
   /**
    * Create or upgrade database schema
    */
-  private createSchema(database: IDBDatabase, _oldVersion: number): void {
+  private createSchema(
+    database: Parameters<NonNullable<DatabaseConfig['onUpgrade']>>[0],
+    _oldVersion: number,
+  ): void {
     // Create vectors store if it doesn't exist
     if (!database.objectStoreNames.contains(VectorDatabase.STORES.VECTORS)) {
       const vectorStore = database.createObjectStore(VectorDatabase.STORES.VECTORS, {
@@ -200,13 +208,13 @@ export class VectorDatabase {
    */
   async transaction(
     storeNames: string | string[],
-    mode: IDBTransactionMode = 'readonly',
-  ): Promise<IDBTransaction> {
+    mode: IndexedDatabaseTransactionMode = 'readonly',
+  ): Promise<IndexedDatabaseTransaction> {
     const database = await this.getDatabase();
 
     try {
       const stores = Array.isArray(storeNames) ? storeNames : [storeNames];
-      return database.transaction(stores, mode);
+      return database.transaction(stores, mode) as IndexedDatabaseTransaction;
     } catch (error) {
       throw new TransactionError(
         'create transaction',
@@ -221,8 +229,8 @@ export class VectorDatabase {
    */
   async executeTransaction<T>(
     storeNames: string | string[],
-    mode: IDBTransactionMode,
-    operation: (transaction: IDBTransaction) => Promise<T>,
+    mode: IndexedDatabaseTransactionMode,
+    operation: (transaction: IndexedDatabaseTransaction) => Promise<T>,
   ): Promise<T> {
     const transaction = await this.transaction(storeNames, mode);
 
@@ -353,7 +361,7 @@ export class VectorDatabase {
   /**
    * Get all available databases (Chrome only)
    */
-  static async getAllDatabases(): Promise<IDBDatabaseInfo[]> {
+  static async getAllDatabases(): Promise<IndexedDatabaseInfo[]> {
     if ('databases' in indexedDB) {
       return indexedDB.databases();
     }

--- a/src/core/storage.ts
+++ b/src/core/storage.ts
@@ -1,7 +1,13 @@
 import { log } from '@/utilities/logger.js';
 import { VectorDatabase } from './database.js';
 import { BatchOperationError, TransactionError, VectorNotFoundError } from './errors.js';
-import type { BatchOptions, BatchProgress, StorageAdapter, VectorData } from './types.js';
+import type {
+  BatchOptions,
+  BatchProgress,
+  IndexedDatabaseObjectStore,
+  StorageAdapter,
+  VectorData,
+} from './types.js';
 
 // Default batch size constant
 const DEFAULT_BATCH_SIZE = 1000;
@@ -78,7 +84,7 @@ export class VectorStorage implements StorageAdapter {
         const store = transaction.objectStore(VectorDatabase.STORES.VECTORS);
 
         return new Promise<VectorData>((resolve, reject) => {
-          const request = store.get(id);
+          const request = store.get<VectorData>(id);
 
           request.onsuccess = () => {
             const vector = request.result;
@@ -137,7 +143,7 @@ export class VectorStorage implements StorageAdapter {
           ids.map(
             (id) =>
               new Promise<void>((resolve) => {
-                const request = store.get(id);
+                const request = store.get<VectorData>(id);
 
                 request.onsuccess = () => {
                   const vector = request.result;
@@ -272,7 +278,7 @@ export class VectorStorage implements StorageAdapter {
             (id) =>
               new Promise<void>((resolve) => {
                 // Check existence before deleting to report accurate count
-                const getRequest = store.get(id);
+                const getRequest = store.get<VectorData>(id);
 
                 getRequest.onsuccess = () => {
                   if (!getRequest.result) {
@@ -344,7 +350,7 @@ export class VectorStorage implements StorageAdapter {
         const store = transaction.objectStore(VectorDatabase.STORES.VECTORS);
 
         return new Promise<VectorData[]>((resolve, reject) => {
-          const request = store.getAll();
+          const request = store.getAll<VectorData>();
 
           request.onsuccess = () => resolve(request.result || []);
           request.onerror = () =>
@@ -711,11 +717,11 @@ export class VectorStorage implements StorageAdapter {
    * Get a vector from store within a transaction
    */
   private async getVectorFromStore(
-    store: IDBObjectStore,
+    store: IndexedDatabaseObjectStore,
     id: string,
   ): Promise<VectorData | null> {
     return new Promise((resolve, reject) => {
-      const request = store.get(id);
+      const request = store.get<VectorData>(id);
 
       request.onsuccess = () => {
         resolve(request.result || null);
@@ -737,7 +743,7 @@ export class VectorStorage implements StorageAdapter {
    * Put a vector into store within a transaction
    */
   private async putVectorInStore(
-    store: IDBObjectStore,
+    store: IndexedDatabaseObjectStore,
     vector: VectorData,
   ): Promise<void> {
     return new Promise((resolve, reject) => {

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -53,9 +53,46 @@ export interface IndexedDatabaseObjectStore {
     keyPath: string | string[],
     options?: { unique?: boolean; multiEntry?: boolean },
   ): unknown;
+  add<T = unknown>(value: T, key?: unknown): IndexedDatabaseRequest<unknown>;
+  put<T = unknown>(value: T, key?: unknown): IndexedDatabaseRequest<unknown>;
+  get<T = unknown>(query: unknown): IndexedDatabaseRequest<T | undefined>;
+  getAll<T = unknown>(query?: unknown, count?: number): IndexedDatabaseRequest<T[]>;
+  delete(query: unknown): IndexedDatabaseRequest<undefined>;
+  clear(): IndexedDatabaseRequest<undefined>;
+  count(query?: unknown): IndexedDatabaseRequest<number>;
+  openCursor<T = unknown>(
+    query?: unknown,
+    direction?: string,
+  ): IndexedDatabaseRequest<IndexedDatabaseCursor<T> | null>;
 }
 
 export type IndexedDatabaseTransactionMode = 'readonly' | 'readwrite' | 'versionchange';
+
+export interface IndexedDatabaseRequest<T = unknown> {
+  onsuccess: ((event: unknown) => void) | null;
+  onerror: ((event: unknown) => void) | null;
+  readonly result: T;
+  readonly error: Error | null;
+}
+
+export interface IndexedDatabaseCursor<T = unknown> {
+  readonly value: T;
+  continue(): void;
+}
+
+export interface IndexedDatabaseTransaction {
+  oncomplete: ((event: unknown) => void) | null;
+  onerror: ((event: unknown) => void) | null;
+  onabort: ((event: unknown) => void) | null;
+  readonly error: Error | null;
+  objectStore(name: string): IndexedDatabaseObjectStore;
+  abort(): void;
+}
+
+export interface IndexedDatabaseInfo {
+  name?: string;
+  version?: number;
+}
 
 export interface VectorAbortSignal {
   readonly aborted: boolean;

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -57,6 +57,10 @@ export interface IndexedDatabaseObjectStore {
 
 export type IndexedDatabaseTransactionMode = 'readonly' | 'readwrite' | 'versionchange';
 
+export interface VectorAbortSignal {
+  readonly aborted: boolean;
+}
+
 /**
  * Database configuration
  */
@@ -136,7 +140,7 @@ export interface SearchOptions {
   includeVector?: boolean;
   includeMetadata?: boolean;
   timeout?: number;
-  signal?: AbortSignal;
+  signal?: VectorAbortSignal;
 }
 
 /**
@@ -193,7 +197,7 @@ export interface FilterOperator {
 export interface BatchOptions {
   batchSize?: number;
   onProgress?: (progress: BatchProgress) => void;
-  abortSignal?: AbortSignal;
+  abortSignal?: VectorAbortSignal;
   parallel?: boolean;
 }
 

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -34,6 +34,29 @@ export interface VectorData {
   };
 }
 
+export interface IndexedDatabaseObjectStoreNames {
+  contains(name: string): boolean;
+}
+
+export interface IndexedDatabaseUpgradeDatabase {
+  objectStoreNames: IndexedDatabaseObjectStoreNames;
+  createObjectStore(
+    name: string,
+    options?: { keyPath?: string | string[]; autoIncrement?: boolean },
+  ): IndexedDatabaseObjectStore;
+  deleteObjectStore(name: string): void;
+}
+
+export interface IndexedDatabaseObjectStore {
+  createIndex(
+    name: string,
+    keyPath: string | string[],
+    options?: { unique?: boolean; multiEntry?: boolean },
+  ): unknown;
+}
+
+export type IndexedDatabaseTransactionMode = 'readonly' | 'readwrite' | 'versionchange';
+
 /**
  * Database configuration
  */
@@ -42,7 +65,7 @@ export interface DatabaseConfig {
   version?: number;
   persistence?: boolean;
   /** Optional callback to override default schema creation during upgrades */
-  onUpgrade?: (database: IDBDatabase, oldVersion: number) => void;
+  onUpgrade?: (database: IndexedDatabaseUpgradeDatabase, oldVersion: number) => void;
 }
 
 /**
@@ -246,7 +269,7 @@ export interface KDTreeParameters {
  */
 export interface TransactionOptions {
   stores?: string[];
-  mode?: IDBTransactionMode;
+  mode?: IndexedDatabaseTransactionMode;
   timeout?: number;
   retries?: number;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -128,5 +128,5 @@ export {
   type EvictionResult,
 } from './storage/eviction-policy.js';
 
-// Version — sourced from package.json to maintain a single source of truth
-export { version as VERSION } from '../package.json';
+// Version
+export const VERSION = '1.0.0-beta.1';

--- a/src/namespaces/registry.ts
+++ b/src/namespaces/registry.ts
@@ -6,6 +6,8 @@ import {
 } from '@/core/errors.js';
 import type {
   IndexedDatabaseUpgradeDatabase,
+  IndexedDatabaseRequest,
+  IndexedDatabaseTransaction,
   NamespaceConfig,
   NamespaceInfo,
   NamespaceStats,
@@ -87,7 +89,7 @@ export class NamespaceRegistry {
       await this.database.executeTransaction(
         [NamespaceRegistry.STORES.NAMESPACES],
         'readwrite',
-        async (tx: IDBTransaction) => {
+        async (tx: IndexedDatabaseTransaction) => {
           const namespaceStore = tx.objectStore(NamespaceRegistry.STORES.NAMESPACES);
 
           // Check if namespace already exists
@@ -127,7 +129,7 @@ export class NamespaceRegistry {
       const result = await this.database.executeTransaction(
         [NamespaceRegistry.STORES.NAMESPACES],
         'readonly',
-        async (tx: IDBTransaction) => {
+        async (tx: IndexedDatabaseTransaction) => {
           const namespaceStore = tx.objectStore(NamespaceRegistry.STORES.NAMESPACES);
           return this.promisifyRequest(namespaceStore.get(name)) as Promise<
             NamespaceInfo | undefined
@@ -154,11 +156,11 @@ export class NamespaceRegistry {
       return await this.database.executeTransaction(
         [NamespaceRegistry.STORES.NAMESPACES],
         'readonly',
-        async (tx: IDBTransaction) => {
+        async (tx: IndexedDatabaseTransaction) => {
           const namespaceStore = tx.objectStore(NamespaceRegistry.STORES.NAMESPACES);
           const namespaces: NamespaceInfo[] = [];
 
-          const cursor = namespaceStore.openCursor();
+          const cursor = namespaceStore.openCursor<NamespaceInfo>();
           await this.iterateCursor(cursor, (value) => {
             namespaces.push(value);
           });
@@ -185,7 +187,7 @@ export class NamespaceRegistry {
       await this.database.executeTransaction(
         [NamespaceRegistry.STORES.NAMESPACES],
         'readwrite',
-        async (tx: IDBTransaction) => {
+        async (tx: IndexedDatabaseTransaction) => {
           const namespaceStore = tx.objectStore(NamespaceRegistry.STORES.NAMESPACES);
 
           const namespace = (await this.promisifyRequest(namespaceStore.get(name))) as
@@ -225,7 +227,7 @@ export class NamespaceRegistry {
       await this.database.executeTransaction(
         [NamespaceRegistry.STORES.NAMESPACES],
         'readwrite',
-        async (tx: IDBTransaction) => {
+        async (tx: IndexedDatabaseTransaction) => {
           const namespaceStore = tx.objectStore(NamespaceRegistry.STORES.NAMESPACES);
 
           const namespace = (await this.promisifyRequest(namespaceStore.get(name))) as
@@ -315,7 +317,7 @@ export class NamespaceRegistry {
   /**
    * Helper to promisify IndexedDB requests
    */
-  private promisifyRequest<T>(request: IDBRequest<T>): Promise<T> {
+  private promisifyRequest<T>(request: IndexedDatabaseRequest<T>): Promise<T> {
     return new Promise((resolve, reject) => {
       request.onsuccess = () => resolve(request.result);
       request.onerror = () =>
@@ -327,7 +329,10 @@ export class NamespaceRegistry {
    * Helper to iterate over a cursor
    */
   private async iterateCursor(
-    cursorRequest: IDBRequest<IDBCursorWithValue | null>,
+    cursorRequest: IndexedDatabaseRequest<{
+      readonly value: NamespaceInfo;
+      continue(): void;
+    } | null>,
     callback: (value: NamespaceInfo) => void,
   ): Promise<void> {
     return new Promise((resolve, reject) => {

--- a/src/namespaces/registry.ts
+++ b/src/namespaces/registry.ts
@@ -4,7 +4,12 @@ import {
   NamespaceNotFoundError,
   TransactionError,
 } from '@/core/errors.js';
-import type { NamespaceConfig, NamespaceInfo, NamespaceStats } from '@/core/types.js';
+import type {
+  IndexedDatabaseUpgradeDatabase,
+  NamespaceConfig,
+  NamespaceInfo,
+  NamespaceStats,
+} from '@/core/types.js';
 import { validateNamespaceName } from './validate-namespace-name.js';
 
 /**
@@ -23,7 +28,7 @@ export class NamespaceRegistry {
     this.database = new VectorDatabase({
       name: rootDatabaseName,
       version: 1,
-      onUpgrade: (db: IDBDatabase) => {
+      onUpgrade: (db: IndexedDatabaseUpgradeDatabase) => {
         // Namespaces store
         if (!db.objectStoreNames.contains(NamespaceRegistry.STORES.NAMESPACES)) {
           const namespaceStore = db.createObjectStore(

--- a/src/search/index-persistence.ts
+++ b/src/search/index-persistence.ts
@@ -92,7 +92,11 @@ export class IndexPersistence {
         return new Promise<
           { id: string; data: SerializableHNSWIndex; timestamp: number } | undefined
         >((resolve, reject) => {
-          const request = store.get(indexId);
+          const request = store.get<{
+            id: string;
+            data: SerializableHNSWIndex;
+            timestamp: number;
+          }>(indexId);
 
           request.onsuccess = () => resolve(request.result);
           request.onerror = () =>
@@ -167,7 +171,11 @@ export class IndexPersistence {
         return new Promise<
           Array<{ id: string; data: SerializableHNSWIndex; timestamp: number }>
         >((resolve, reject) => {
-          const request = store.getAll();
+          const request = store.getAll<{
+            id: string;
+            data: SerializableHNSWIndex;
+            timestamp: number;
+          }>();
 
           request.onsuccess = () => resolve(request.result || []);
           request.onerror = () =>


### PR DESCRIPTION
## Summary
- publish documented storage adapter subpaths under `vector-frankl/adapters/*`
- add package-surface verification for export-map entry points and declaration import rewriting
- remove DOM-only and package-json leaks from public declarations for non-DOM consumers

## Verification
- `bun run package:check`
- `rg -n "\\b(IDBDatabase|IDBTransactionMode|IDBTransaction|IDBDatabaseInfo|IDBObjectStore|IDBRequest|IDBCursorWithValue|AbortSignal)\\b|package\\.json" dist --glob '*.d.ts' --glob '!*.map' || true` produced no output
- `rg -n "from ['\\\"]@/|import\\(['\\\"]@/" dist --glob '*.d.ts' --glob '*.js' --glob '!*.map' || true` produced no output
- installed tarball smoke test importing root and adapter subpaths in a non-DOM TypeScript consumer passed
- `bun run format:check`
- `bun run lint`
- `bun run typecheck`
- `bun run test`
- `git diff --check`
- pre-push hook passed tests, build, secret scan, and lint

## Committee Review
- TypeScript/API reviewer: APPROVED
- Testing/CI reviewer: APPROVED
- Simplicity reviewer: APPROVED

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the published export map and `.d.ts` surface (adapter import paths and IndexedDB/abort types), which can break consumers on deep imports or strict typing; runtime behavior is mostly typing and packaging.
> 
> **Overview**
> This PR **publishes documented storage adapter entry points** as `vector-frankl/adapters/*` in `package.json`, adds a **`build:adapters`** step to emit ESM adapter bundles, and runs **`rewrite-declaration-imports.ts`** after `tsc` so `@/` paths in `.d.ts` files become relative imports in the published package.
> 
> **README** examples now import adapters from those subpaths (e.g. `vector-frankl/adapters/sqlite`) instead of deep `src/` paths. **CHANGELOG** records the new exports.
> 
> **Public TypeScript surface** for non-DOM consumers is tightened: DOM-only types are replaced with library-owned **`IndexedDatabase*`** shapes and **`VectorAbortSignal`** in `types.ts`, with call sites updated in core DB/storage, namespace registry, and index persistence. **`VERSION`** is exported as a fixed string from `index.ts` rather than re-exporting `package.json`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed80a84477e99d951264077f6020b7e1979d9bba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->