### PR TITLE
chore: ignore .claude/ in git and ESLint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -114,3 +114,6 @@ REQUIREMENTS.md
 # Stray build artifacts — src is TypeScript-only
 src/**/*.js
 tmp/
+
+# Claude Code agent worktrees and local state (untracked, machine-local)
+.claude/

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -93,6 +93,7 @@ export default [
       '**/*.lock',
       '**/README.md',
       '**/package.json',
+      '.claude/**',
     ],
   },
 


### PR DESCRIPTION
## Summary

The `.claude/` directory holds Claude Code agent worktrees and local state. It is untracked and machine-local, but it was neither in `.gitignore` nor in the ESLint ignore list. As a result, `eslint .` — and the pre-push hook that runs it — would walk into `.claude/worktrees/` and fail with TypeScript parser errors on files not present in the project's `tsconfig.json` whenever an agent worktree existed.

This was hit directly while merging a batch of dependabot PRs: a clean dependabot bump could not be pushed because sibling agent worktrees under `.claude/worktrees/` made the pre-push `eslint .` blow up with ~1000 parser errors unrelated to the change.

Changes:
- Add `.claude/` to `.gitignore` (untracked, machine-local — never tracked).
- Add `.claude/**` to the ESLint global `ignores` so local agent worktrees never interfere with linting or the pre-push hook.

## Review committee

Pre-reviewed by: dx-engineer, simplicity-engineer
- 1 round of review, both APPROVED with no must-fix items
- Codex (adversarial second opinion) was unavailable this run — see warning below

> [!WARNING]
> Codex (the adversarial second-opinion reviewer) was unavailable for this PR (usage limit). See `tmp/committee-state.md` for detail.

## Test plan

- `bun run lint` passes (0 errors) — and no longer depends on the absence of `.claude/worktrees/`.
- With an agent worktree present under `.claude/`, `eslint .` no longer descends into it.
- `.claude/` no longer appears in `git status` as untracked clutter.

## Note (out of scope)

`tmp/` is listed twice in `.gitignore` (pre-existing, not introduced here). Left untouched to keep this change surgical.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only ignores with no runtime or application behavior changes.
> 
> **Overview**
> **Ignores local Claude Code agent state** so it no longer pollutes `git status` or breaks repo-wide linting.
> 
> Adds `.claude/` to `.gitignore` and `.claude/**` to the global ESLint `ignores` in `eslint.config.js`. That stops `eslint .` (and the pre-push hook that runs it) from walking into `.claude/worktrees/` and failing with TypeScript parser errors on files outside the project `tsconfig.json` when agent worktrees exist on disk.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 70ec01b095a62217d468678f00ca2e9ea921a59f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->